### PR TITLE
Refactor imports to use the new filterable-api package structure and …

### DIFF
--- a/application-core/build.gradle.kts
+++ b/application-core/build.gradle.kts
@@ -35,8 +35,9 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    implementation("com.JPolanco:core:1.0.0-SNAPSHOT")
-    implementation("com.JPolanco:spring-extension:1.0.0-SNAPSHOT")
+    implementation("io.github.jose-polanco-oxte:filterable-api-core:1.0.1")
+    implementation("io.github.jose-polanco-oxte:filterable-api-spring-extension:1.0.1")
+
     implementation("com.google.zxing:javase:3.5.3")
     implementation("io.jsonwebtoken:jjwt:0.12.6")
     implementation("com.google.zxing:core:3.5.3")

--- a/application-core/src/main/java/jpolanco/applicationcore/user/infrastructure/adapters/input/dto/request/AdminUserFilterRequest.java
+++ b/application-core/src/main/java/jpolanco/applicationcore/user/infrastructure/adapters/input/dto/request/AdminUserFilterRequest.java
@@ -1,12 +1,12 @@
 package jpolanco.applicationcore.user.infrastructure.adapters.input.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import filters.CollectionFilter;
-import filters.Filter;
-import filters.operations.ComparableOperation;
-import filters.operations.InOperation;
-import filters.operations.TextCollectionOperation;
-import filters.operations.TextOperation;
+import io.github.josepolanco.filterable.filters.CollectionFilter;
+import io.github.josepolanco.filterable.filters.Filter;
+import io.github.josepolanco.filterable.filters.operations.ComparableOperation;
+import io.github.josepolanco.filterable.filters.operations.InOperation;
+import io.github.josepolanco.filterable.filters.operations.TextCollectionOperation;
+import io.github.josepolanco.filterable.filters.operations.TextOperation;
 import jakarta.validation.Valid;
 import jpolanco.domainmodel.user.UserStatusE;
 import org.springframework.validation.annotation.Validated;

--- a/application-core/src/main/java/jpolanco/applicationcore/user/infrastructure/adapters/input/dto/request/DefaultUserFilterRequest.java
+++ b/application-core/src/main/java/jpolanco/applicationcore/user/infrastructure/adapters/input/dto/request/DefaultUserFilterRequest.java
@@ -1,12 +1,12 @@
 package jpolanco.applicationcore.user.infrastructure.adapters.input.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import filters.CollectionFilter;
-import filters.Filter;
-import filters.operations.ComparableOperation;
-import filters.operations.InOperation;
-import filters.operations.TextCollectionOperation;
-import filters.operations.TextOperation;
+import io.github.josepolanco.filterable.filters.CollectionFilter;
+import io.github.josepolanco.filterable.filters.Filter;
+import io.github.josepolanco.filterable.filters.operations.ComparableOperation;
+import io.github.josepolanco.filterable.filters.operations.InOperation;
+import io.github.josepolanco.filterable.filters.operations.TextCollectionOperation;
+import io.github.josepolanco.filterable.filters.operations.TextOperation;
 import jakarta.validation.Valid;
 import org.springframework.validation.annotation.Validated;
 

--- a/application-core/src/main/java/jpolanco/applicationcore/user/infrastructure/adapters/output/mysql/UserPageableRepositoryMySQL.java
+++ b/application-core/src/main/java/jpolanco/applicationcore/user/infrastructure/adapters/output/mysql/UserPageableRepositoryMySQL.java
@@ -1,6 +1,6 @@
 package jpolanco.applicationcore.user.infrastructure.adapters.output.mysql;
 
-import api.FilterableApi;
+import io.github.josepolanco.filterable.api.FilterableApi;
 import jpolanco.applicationcore.shared.application.pageable.Cursored;
 import jpolanco.applicationcore.shared.application.pageable.PageMapper;
 import jpolanco.applicationcore.shared.application.pageable.Paged;
@@ -26,7 +26,7 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
-import static jpolanco.springextension.SpringSpecificationWrapper.from;
+import static io.github.josepolanco.filterable.spring.Wrapper.from;
 
 @Repository
 @RequiredArgsConstructor


### PR DESCRIPTION
This pull request updates the project to use the latest version of the `filterable-api` library and its Spring extension, switching from local or custom packages to the published `io.github.jose-polanco-oxte` artifacts. It also updates all relevant import statements throughout the codebase to reflect the new package structure.

Dependency and import updates:

* Updated dependencies in `application-core/build.gradle.kts` to use `io.github.jose-polanco-oxte:filterable-api-core:1.0.1` and `io.github.jose-polanco-oxte:filterable-api-spring-extension:1.0.1` instead of the previous `com.JPolanco` versions.

Java import refactoring:

* Updated imports in `AdminUserFilterRequest.java` and `DefaultUserFilterRequest.java` to use the new `io.github.josepolanco.filterable` package paths for all filter-related classes and operations. [[1]](diffhunk://#diff-cbe0b09869d231bbcc2a6545edf78f3a79dc77aa44e78ed3c1a32064a81b4cddL4-R9) [[2]](diffhunk://#diff-d72248c74f874b4169f181a4821cb00e17bfed5793f4432589d4160d80f52f78L4-R9)
* Updated `UserPageableRepositoryMySQL.java` to import `FilterableApi` from the new package.
* Changed the static import in `UserPageableRepositoryMySQL.java` to use `io.github.josepolanco.filterable.spring.Wrapper.from` instead of the old Spring extension path.…update dependencies in build.gradle.kts